### PR TITLE
feat: scaffold operator cloud workspace

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { AuditInterceptor } from "./common/interceptors/audit.interceptor";
 import { TracingInterceptor } from "./observability/tracing.interceptor";
 import { MetricsInterceptor } from "./observability/metrics.interceptor";
 import { LoggerInterceptor } from "./observability/logger.interceptor";
+import { OperatorModule } from "./operator/operator.module";
 
 import dataSourceOptions from "./database/typeorm.config";
 
@@ -32,6 +33,7 @@ import dataSourceOptions from "./database/typeorm.config";
     ExportsModule,
     DppModule,
     ReportsModule,
+    OperatorModule,
   ],
   providers: [
     {

--- a/apps/api/src/operator/dto/assign-lot.dto.ts
+++ b/apps/api/src/operator/dto/assign-lot.dto.ts
@@ -1,0 +1,14 @@
+import { IsString } from "class-validator";
+
+import { OperatorAssignLotPayload } from "@qa-dashboard/shared";
+
+export class AssignLotDto implements OperatorAssignLotPayload {
+  @IsString()
+  lotId!: string;
+
+  @IsString()
+  styleRef!: string;
+
+  @IsString()
+  customer!: string;
+}

--- a/apps/api/src/operator/dto/create-flag.dto.ts
+++ b/apps/api/src/operator/dto/create-flag.dto.ts
@@ -1,0 +1,17 @@
+import { IsIn, IsOptional, IsString } from "class-validator";
+
+import { OperatorFlagPayload } from "@qa-dashboard/shared";
+
+const FLAG_SEVERITIES = ["info", "warning", "critical"] as const;
+
+export class CreateFlagDto implements OperatorFlagPayload {
+  @IsString()
+  eventId!: string;
+
+  @IsString()
+  note!: string;
+
+  @IsOptional()
+  @IsIn(FLAG_SEVERITIES)
+  severity?: "info" | "warning" | "critical";
+}

--- a/apps/api/src/operator/dto/reprint-command.dto.ts
+++ b/apps/api/src/operator/dto/reprint-command.dto.ts
@@ -1,0 +1,16 @@
+import { IsNumber, IsOptional, IsString, Min } from "class-validator";
+
+import { OperatorReprintPayload } from "@qa-dashboard/shared";
+
+export class ReprintCommandDto implements OperatorReprintPayload {
+  @IsString()
+  lotId!: string;
+
+  @IsNumber()
+  @Min(0)
+  pieceSeq!: number;
+
+  @IsOptional()
+  @IsString()
+  reason?: string;
+}

--- a/apps/api/src/operator/operator-devices.controller.ts
+++ b/apps/api/src/operator/operator-devices.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Get, Param, Post, Query } from "@nestjs/common";
+
+import { OperatorService } from "./operator.service";
+import { AssignLotDto } from "./dto/assign-lot.dto";
+import { ReprintCommandDto } from "./dto/reprint-command.dto";
+
+@Controller("operator/devices")
+export class OperatorDevicesController {
+  constructor(private readonly operatorService: OperatorService) {}
+
+  @Get()
+  getDevices(@Query("site") site?: string) {
+    return this.operatorService.getDevices(site);
+  }
+
+  @Get(":id")
+  getDevice(@Param("id") id: string) {
+    return this.operatorService.getDeviceDetail(id);
+  }
+
+  @Post(":id/assign")
+  assignLot(@Param("id") id: string, @Body() payload: AssignLotDto) {
+    return this.operatorService.assignLotToDevice(id, payload);
+  }
+
+  @Post(":id/commands/reprint")
+  issueReprint(
+    @Param("id") id: string,
+    @Body() payload: ReprintCommandDto,
+  ) {
+    return this.operatorService.issueReprintCommand(id, payload);
+  }
+}

--- a/apps/api/src/operator/operator-lots.controller.ts
+++ b/apps/api/src/operator/operator-lots.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Param, Post, Query } from "@nestjs/common";
+
+import { OperatorService } from "./operator.service";
+import { CreateFlagDto } from "./dto/create-flag.dto";
+
+@Controller("operator/lots")
+export class OperatorLotsController {
+  constructor(private readonly operatorService: OperatorService) {}
+
+  @Get("active")
+  getActiveLots(@Query("site") site?: string) {
+    return this.operatorService.getActiveLots(site);
+  }
+
+  @Get(":id/feed")
+  getLotFeed(@Param("id") lotId: string, @Query("site") site?: string) {
+    return this.operatorService.getLotFeed(lotId, site);
+  }
+
+  @Post(":id/flags")
+  createFlag(@Param("id") lotId: string, @Body() payload: CreateFlagDto) {
+    return this.operatorService.createFlag(lotId, payload);
+  }
+}

--- a/apps/api/src/operator/operator-realtime.service.ts
+++ b/apps/api/src/operator/operator-realtime.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, Logger } from "@nestjs/common";
+
+import {
+  OperatorDevice,
+  OperatorCommandResult,
+  OperatorLotFeedItem,
+} from "@qa-dashboard/shared";
+
+@Injectable()
+export class OperatorRealtimeService {
+  private readonly logger = new Logger(OperatorRealtimeService.name);
+
+  emitDeviceAssignmentChanged(device: OperatorDevice): void {
+    this.logger.log(
+      `Device ${device.id} assignment changed to ${device.currentAssignment?.lotId ?? "none"}`,
+    );
+  }
+
+  emitCommandQueued(command: OperatorCommandResult): void {
+    this.logger.log(
+      `Command ${command.commandId} queued for device ${command.deviceId} (${command.type})`,
+    );
+  }
+
+  emitLotFeedUpdated(event: OperatorLotFeedItem): void {
+    this.logger.log(
+      `New ${event.type} event recorded for lot ${event.lotId} on device ${event.deviceId}`,
+    );
+  }
+}

--- a/apps/api/src/operator/operator.module.ts
+++ b/apps/api/src/operator/operator.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+
+import { OperatorService } from "./operator.service";
+import { OperatorDevicesController } from "./operator-devices.controller";
+import { OperatorLotsController } from "./operator-lots.controller";
+import { OperatorRealtimeService } from "./operator-realtime.service";
+
+@Module({
+  controllers: [OperatorDevicesController, OperatorLotsController],
+  providers: [OperatorService, OperatorRealtimeService],
+  exports: [OperatorService],
+})
+export class OperatorModule {}

--- a/apps/api/src/operator/operator.service.ts
+++ b/apps/api/src/operator/operator.service.ts
@@ -1,0 +1,452 @@
+import { randomUUID } from "crypto";
+
+import { Injectable, NotFoundException } from "@nestjs/common";
+
+import {
+  DeviceCommandType,
+  DeviceStatus,
+  EdgeEventType,
+  OperatorAssignLotPayload,
+  OperatorCommandResult,
+  OperatorDevice,
+  OperatorDeviceDetail,
+  OperatorFlagPayload,
+  OperatorLotFeedItem,
+  OperatorLotSummary,
+  OperatorReprintPayload,
+  QueueDepthSample,
+} from "@qa-dashboard/shared";
+
+import { OperatorRealtimeService } from "./operator-realtime.service";
+
+interface DeviceState {
+  device: OperatorDevice;
+  events: OperatorLotFeedItem[];
+  queueDepthHistory: QueueDepthSample[];
+}
+
+interface LotMetadata {
+  lotId: string;
+  lotCode: string;
+  styleRef: string;
+  customer: string;
+}
+
+@Injectable()
+export class OperatorService {
+  private readonly devices = new Map<string, DeviceState>();
+  private readonly lotMetadata = new Map<string, LotMetadata>();
+  private readonly commands: OperatorCommandResult[] = [];
+
+  constructor(private readonly realtime: OperatorRealtimeService) {
+    this.seed();
+  }
+
+  getDevices(site?: string): OperatorDevice[] {
+    return Array.from(this.iterateDeviceStates(site)).map((state) => this.cloneDevice(state));
+  }
+
+  getDeviceDetail(deviceId: string): OperatorDeviceDetail {
+    const state = this.devices.get(deviceId);
+    if (!state) {
+      throw new NotFoundException(`Device ${deviceId} not found`);
+    }
+
+    const recentEvents = state.events.slice(0, 20).map((event) => this.cloneEvent(event));
+    const latestEvent = recentEvents[0];
+
+    const metrics = {
+      pieceSequence: latestEvent?.pieceSequence ?? 0,
+      qaIndicators: latestEvent?.qaMetrics
+        ? { ...latestEvent.qaMetrics }
+        : { status: "ok" as const },
+      lastTranscript: latestEvent?.transcript ?? null,
+    };
+
+    return {
+      ...this.cloneDevice(state),
+      metrics,
+      recentEvents,
+      queueDepthHistory: state.queueDepthHistory.slice(-24).map((sample) => ({ ...sample })),
+    };
+  }
+
+  assignLotToDevice(deviceId: string, payload: OperatorAssignLotPayload): OperatorDeviceDetail {
+    const state = this.devices.get(deviceId);
+    if (!state) {
+      throw new NotFoundException(`Device ${deviceId} not found`);
+    }
+
+    const assignedAt = new Date().toISOString();
+    state.device.currentAssignment = {
+      ...payload,
+      assignedAt,
+      assignedBy: "cloud.supervisor@demo",
+    };
+
+    const metadata = this.resolveLotMetadata(payload.lotId, payload.styleRef, payload.customer);
+
+    const event: OperatorLotFeedItem = {
+      id: randomUUID(),
+      lotId: metadata.lotId,
+      deviceId,
+      type: EdgeEventType.FLAG,
+      timestamp: assignedAt,
+      transcript: `Lot switched to ${metadata.lotCode}`,
+      qaMetrics: {
+        status: "ok",
+      },
+      flag: {
+        note: `Assignment updated to ${metadata.styleRef} / ${metadata.customer}`,
+        createdAt: assignedAt,
+        createdBy: "system",
+        severity: "info",
+      },
+    };
+
+    state.events.unshift(event);
+    if (state.events.length > 100) {
+      state.events.length = 100;
+    }
+
+    this.realtime.emitDeviceAssignmentChanged(state.device);
+    this.realtime.emitLotFeedUpdated(event);
+
+    return this.getDeviceDetail(deviceId);
+  }
+
+  issueReprintCommand(deviceId: string, payload: OperatorReprintPayload): OperatorCommandResult {
+    const state = this.devices.get(deviceId);
+    if (!state) {
+      throw new NotFoundException(`Device ${deviceId} not found`);
+    }
+
+    const command: OperatorCommandResult = {
+      commandId: randomUUID(),
+      deviceId,
+      type: DeviceCommandType.REPRINT_LABEL,
+      status: "QUEUED",
+      createdAt: new Date().toISOString(),
+    };
+
+    this.commands.push(command);
+
+    const acknowledgementEvent: OperatorLotFeedItem = {
+      id: randomUUID(),
+      lotId: payload.lotId,
+      deviceId,
+      type: EdgeEventType.PRINT_LABEL,
+      timestamp: command.createdAt,
+      transcript: `Reprint requested for piece #${payload.pieceSeq}`,
+      qaMetrics: {
+        status: "ok",
+      },
+    };
+
+    state.events.unshift(acknowledgementEvent);
+    if (state.events.length > 100) {
+      state.events.length = 100;
+    }
+
+    this.realtime.emitCommandQueued(command);
+    this.realtime.emitLotFeedUpdated(acknowledgementEvent);
+
+    return command;
+  }
+
+  getActiveLots(site?: string): OperatorLotSummary[] {
+    const summaries = new Map<string, OperatorLotSummary>();
+
+    for (const state of this.iterateDeviceStates(site)) {
+      for (const event of state.events) {
+        const metadata = this.resolveLotMetadata(event.lotId);
+        const summary = summaries.get(event.lotId) ?? {
+          lotId: metadata.lotId,
+          lotCode: metadata.lotCode,
+          customer: metadata.customer,
+          styleRef: metadata.styleRef,
+          activeDeviceIds: [],
+          piecesInspected: 0,
+          defectsFound: 0,
+          defectRate: 0,
+          lastEventAt: null as string | null,
+        };
+
+        if (!summary.activeDeviceIds.includes(event.deviceId)) {
+          summary.activeDeviceIds.push(event.deviceId);
+        }
+
+        if (typeof event.pieceSequence === "number") {
+          summary.piecesInspected = Math.max(summary.piecesInspected, event.pieceSequence);
+        }
+
+        if (event.type === EdgeEventType.DEFECT) {
+          summary.defectsFound += 1;
+        }
+
+        summary.lastEventAt = event.timestamp;
+        summaries.set(event.lotId, summary);
+      }
+    }
+
+    return Array.from(summaries.values())
+      .map((summary) => ({
+        ...summary,
+        defectRate:
+          summary.piecesInspected > 0
+            ? Number((summary.defectsFound / summary.piecesInspected).toFixed(3))
+            : 0,
+      }))
+      .sort((a, b) => (b.lastEventAt ?? "").localeCompare(a.lastEventAt ?? ""));
+  }
+
+  getLotFeed(lotId: string, site?: string): OperatorLotFeedItem[] {
+    const events: OperatorLotFeedItem[] = [];
+
+    for (const state of this.iterateDeviceStates(site)) {
+      for (const event of state.events) {
+        if (event.lotId === lotId) {
+          events.push(this.cloneEvent(event));
+        }
+      }
+    }
+
+    return events.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+  }
+
+  createFlag(lotId: string, payload: OperatorFlagPayload): OperatorLotFeedItem {
+    for (const state of this.devices.values()) {
+      const event = state.events.find((item) => item.id === payload.eventId && item.lotId === lotId);
+      if (event) {
+        const now = new Date().toISOString();
+        event.flag = {
+          note: payload.note,
+          createdAt: now,
+          createdBy: "operator.cloud",
+          severity: payload.severity ?? "info",
+        };
+
+        this.realtime.emitLotFeedUpdated(event);
+        return this.cloneEvent(event);
+      }
+    }
+
+    throw new NotFoundException(`Event ${payload.eventId} not found for lot ${lotId}`);
+  }
+
+  private iterateDeviceStates(site?: string): Iterable<DeviceState> {
+    return Array.from(this.devices.values()).filter((state) =>
+      site ? state.device.site.toLowerCase() === site.toLowerCase() : true,
+    );
+  }
+
+  private cloneDevice(state: DeviceState): OperatorDevice {
+    return {
+      ...state.device,
+      currentAssignment: state.device.currentAssignment
+        ? { ...state.device.currentAssignment }
+        : null,
+    };
+  }
+
+  private cloneEvent(event: OperatorLotFeedItem): OperatorLotFeedItem {
+    return {
+      ...event,
+      qaMetrics: event.qaMetrics ? { ...event.qaMetrics } : undefined,
+      flag: event.flag ? { ...event.flag } : undefined,
+    };
+  }
+
+  private resolveLotMetadata(lotId: string, styleRef?: string, customer?: string): LotMetadata {
+    const existing = this.lotMetadata.get(lotId);
+    if (existing) {
+      return existing;
+    }
+
+    const metadata: LotMetadata = {
+      lotId,
+      lotCode: lotId.toUpperCase(),
+      styleRef: styleRef ?? "Unknown",
+      customer: customer ?? "Unknown",
+    };
+
+    this.lotMetadata.set(lotId, metadata);
+    return metadata;
+  }
+
+  private seed(): void {
+    const now = new Date();
+    const minute = 60 * 1000;
+
+    const lotA: LotMetadata = {
+      lotId: "lot-001",
+      lotCode: "LOT-001",
+      styleRef: "ST-001",
+      customer: "Atelier Norte",
+    };
+
+    const lotB: LotMetadata = {
+      lotId: "lot-002",
+      lotCode: "LOT-002",
+      styleRef: "ST-104",
+      customer: "Green Threads",
+    };
+
+    [lotA, lotB].forEach((lot) => this.lotMetadata.set(lot.lotId, lot));
+
+    const deviceStates: DeviceState[] = [
+      {
+        device: {
+          id: "device-1",
+          name: "North Line A",
+          site: "Porto",
+          status: DeviceStatus.ONLINE,
+          lastSeenAt: new Date(now.getTime() - 30 * 1000).toISOString(),
+          queueDepth: 1,
+          firmwareVersion: "1.4.2",
+          ipAddress: "10.0.0.21",
+          currentAssignment: {
+            lotId: lotA.lotId,
+            styleRef: lotA.styleRef,
+            customer: lotA.customer,
+            assignedAt: new Date(now.getTime() - 5 * minute).toISOString(),
+            assignedBy: "ops.lead@demo",
+          },
+        },
+        events: [
+          {
+            id: randomUUID(),
+            lotId: lotA.lotId,
+            deviceId: "device-1",
+            type: EdgeEventType.PHOTO,
+            timestamp: new Date(now.getTime() - 2 * minute).toISOString(),
+            pieceSequence: 128,
+            thumbnailUrl: "https://placehold.co/280x280?text=Lot+001",
+            transcript: "Piece 128 captured",
+            qaMetrics: {
+              pixelsPerMillimeter: 5.2,
+              sharpnessScore: 0.92,
+              brightnessScore: 0.76,
+              status: "ok",
+            },
+          },
+          {
+            id: randomUUID(),
+            lotId: lotA.lotId,
+            deviceId: "device-1",
+            type: EdgeEventType.DEFECT,
+            timestamp: new Date(now.getTime() - 4 * minute).toISOString(),
+            pieceSequence: 127,
+            thumbnailUrl: "https://placehold.co/280x280?text=Defect",
+            defectText: "Loose thread near collar",
+            qaMetrics: {
+              pixelsPerMillimeter: 5.1,
+              sharpnessScore: 0.81,
+              brightnessScore: 0.72,
+              status: "warning",
+            },
+          },
+          {
+            id: randomUUID(),
+            lotId: lotA.lotId,
+            deviceId: "device-1",
+            type: EdgeEventType.PIECE_END,
+            timestamp: new Date(now.getTime() - 6 * minute).toISOString(),
+            pieceSequence: 126,
+            transcript: "Piece complete",
+            qaMetrics: {
+              status: "ok",
+            },
+          },
+        ],
+        queueDepthHistory: Array.from({ length: 6 }).map((_, index) => ({
+          timestamp: new Date(now.getTime() - index * minute).toISOString(),
+          depth: Math.max(0, 3 - index),
+        })),
+      },
+      {
+        device: {
+          id: "device-2",
+          name: "North Line B",
+          site: "Porto",
+          status: DeviceStatus.DEGRADED,
+          lastSeenAt: new Date(now.getTime() - 4 * minute).toISOString(),
+          queueDepth: 4,
+          firmwareVersion: "1.3.9",
+          ipAddress: "10.0.0.22",
+          currentAssignment: {
+            lotId: lotB.lotId,
+            styleRef: lotB.styleRef,
+            customer: lotB.customer,
+            assignedAt: new Date(now.getTime() - 45 * minute).toISOString(),
+            assignedBy: "ops.lead@demo",
+          },
+        },
+        events: [
+          {
+            id: randomUUID(),
+            lotId: lotB.lotId,
+            deviceId: "device-2",
+            type: EdgeEventType.PHOTO,
+            timestamp: new Date(now.getTime() - 3 * minute).toISOString(),
+            pieceSequence: 88,
+            thumbnailUrl: "https://placehold.co/280x280?text=Lot+002",
+            transcript: "Piece 88 captured",
+            qaMetrics: {
+              pixelsPerMillimeter: 4.8,
+              sharpnessScore: 0.7,
+              brightnessScore: 0.69,
+              status: "warning",
+            },
+          },
+          {
+            id: randomUUID(),
+            lotId: lotB.lotId,
+            deviceId: "device-2",
+            type: EdgeEventType.HEARTBEAT,
+            timestamp: new Date(now.getTime() - 5 * minute).toISOString(),
+            qaMetrics: {
+              status: "ok",
+            },
+          },
+        ],
+        queueDepthHistory: Array.from({ length: 6 }).map((_, index) => ({
+          timestamp: new Date(now.getTime() - index * minute).toISOString(),
+          depth: Math.max(1, 4 - index),
+        })),
+      },
+      {
+        device: {
+          id: "device-3",
+          name: "South Pilot",
+          site: "Guimarães",
+          status: DeviceStatus.OFFLINE,
+          lastSeenAt: new Date(now.getTime() - 60 * minute).toISOString(),
+          queueDepth: 0,
+          firmwareVersion: "1.4.0",
+          ipAddress: "10.0.1.10",
+          currentAssignment: null,
+        },
+        events: [],
+        queueDepthHistory: Array.from({ length: 6 }).map((_, index) => ({
+          timestamp: new Date(now.getTime() - index * minute).toISOString(),
+          depth: 0,
+        })),
+      },
+    ];
+
+    deviceStates.forEach((state) => {
+      this.devices.set(state.device.id, state);
+      if (state.device.currentAssignment) {
+        this.resolveLotMetadata(
+          state.device.currentAssignment.lotId,
+          state.device.currentAssignment.styleRef,
+          state.device.currentAssignment.customer,
+        );
+      }
+      state.events.forEach((event) => {
+        this.resolveLotMetadata(event.lotId);
+      });
+    });
+  }
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useAuth } from '@/components/providers/auth-provider'
 import { apiClient } from '@/lib/api'
 import { storeUser } from '@/lib/auth'
+import { UserRole } from '@qa-dashboard/shared'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -23,7 +24,6 @@ export default function LoginPage() {
       const response = await apiClient.login({ email, password })
       
       const clientSlug = email.includes('marly.example') ? 'heymarly' : 'samplebrand'
-
       const userWithSlug = {
         ...response.user,
         clientSlug,
@@ -32,7 +32,15 @@ export default function LoginPage() {
       storeUser(userWithSlug)
       setUser(userWithSlug)
 
-      router.push(`/c/${clientSlug}/feed`)
+      const isOperator = response.user.roles.some((role) =>
+        [UserRole.OPERATOR, UserRole.SUPERVISOR].includes(role),
+      )
+
+      if (isOperator) {
+        router.push('/operator')
+      } else {
+        router.push(`/c/${clientSlug}/feed`)
+      }
     } catch (err: any) {
       setError(err.message || 'Login failed')
     } finally {

--- a/apps/web/src/app/operator/device/[id]/page.tsx
+++ b/apps/web/src/app/operator/device/[id]/page.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { FormEvent, useEffect, useMemo, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { ArrowLeftIcon, Loader2Icon } from 'lucide-react'
+import Link from 'next/link'
+
+import { DeviceStatusPill } from '@/components/operator/device-status-pill'
+import { DeviceMetrics } from '@/components/operator/device-metrics'
+import { QueueDepthCard } from '@/components/operator/queue-depth-card'
+import { EventFeed } from '@/components/operator/event-feed'
+import { apiClient } from '@/lib/api'
+
+export default function OperatorDeviceDetailPage() {
+  const params = useParams<{ id: string }>()
+  const deviceId = params?.id
+  const queryClient = useQueryClient()
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const { data: device, isLoading } = useQuery({
+    queryKey: ['operator', 'device', deviceId],
+    queryFn: () => apiClient.getOperatorDevice(deviceId!),
+    enabled: !!deviceId,
+  })
+
+  const assignMutation = useMutation({
+    mutationFn: apiClient.assignOperatorDevice.bind(apiClient, deviceId!),
+    onSuccess: (updated) => {
+      queryClient.setQueryData(['operator', 'device', deviceId], updated)
+      queryClient.invalidateQueries({ queryKey: ['operator', 'devices'] })
+      queryClient.invalidateQueries({ queryKey: ['operator', 'lots'] })
+      setFeedback('Device assignment updated successfully')
+      setError(null)
+    },
+    onError: (err: Error) => {
+      setError(err.message)
+      setFeedback(null)
+    },
+  })
+
+  const reprintMutation = useMutation({
+    mutationFn: apiClient.issueReprintCommand.bind(apiClient, deviceId!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['operator', 'device', deviceId] })
+      queryClient.invalidateQueries({ queryKey: ['operator', 'lots'] })
+      setFeedback('Reprint command queued')
+      setError(null)
+    },
+    onError: (err: Error) => {
+      setError(err.message)
+      setFeedback(null)
+    },
+  })
+
+  const [assignmentForm, setAssignmentForm] = useState({
+    lotId: '',
+    styleRef: '',
+    customer: '',
+  })
+
+  const [reprintForm, setReprintForm] = useState({
+    lotId: '',
+    pieceSeq: 0,
+    reason: '',
+  })
+
+  useEffect(() => {
+    if (device?.currentAssignment) {
+      setAssignmentForm({
+        lotId: device.currentAssignment.lotId,
+        styleRef: device.currentAssignment.styleRef,
+        customer: device.currentAssignment.customer,
+      })
+      setReprintForm((prev) => ({ ...prev, lotId: device.currentAssignment!.lotId }))
+    }
+  }, [device?.currentAssignment])
+
+  const handleAssign = (event: FormEvent) => {
+    event.preventDefault()
+    assignMutation.mutate({ ...assignmentForm })
+  }
+
+  const handleReprint = (event: FormEvent) => {
+    event.preventDefault()
+    reprintMutation.mutate({ ...reprintForm, pieceSeq: Number(reprintForm.pieceSeq) })
+  }
+
+  const currentAssignment = useMemo(() => device?.currentAssignment ?? null, [device])
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <Link href="/operator" className="inline-flex items-center gap-1 text-sm text-slate-600 hover:text-slate-900">
+          <ArrowLeftIcon className="h-4 w-4" aria-hidden />
+          Back to devices
+        </Link>
+
+        {isLoading || !device ? (
+          <div className="flex min-h-[200px] items-center justify-center">
+            <Loader2Icon className="h-8 w-8 animate-spin text-primary-500" />
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-500">{device.site}</p>
+                <h2 className="text-2xl font-semibold text-slate-900">{device.name}</h2>
+                <p className="text-sm text-slate-600">
+                  Last seen {device.lastSeenAt ? new Date(device.lastSeenAt).toLocaleTimeString() : '—'}
+                </p>
+              </div>
+              <DeviceStatusPill status={device.status} />
+            </div>
+
+            {feedback && (
+              <div className="rounded-lg bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{feedback}</div>
+            )}
+            {error && <div className="rounded-lg bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>}
+
+            <DeviceMetrics device={device} />
+
+            <div className="grid gap-4 lg:grid-cols-3">
+              <div className="space-y-4 lg:col-span-2">
+                <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <h3 className="text-sm font-semibold text-slate-700">Assignment</h3>
+                  {currentAssignment ? (
+                    <p className="mt-2 text-sm text-slate-600">
+                      Lot {currentAssignment.lotId} &mdash; {currentAssignment.styleRef} for {currentAssignment.customer}
+                    </p>
+                  ) : (
+                    <p className="mt-2 text-sm text-slate-500">No lot assigned</p>
+                  )}
+
+                  <form onSubmit={handleAssign} className="mt-4 grid gap-3 md:grid-cols-3">
+                    <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                      Lot ID
+                      <input
+                        required
+                        value={assignmentForm.lotId}
+                        onChange={(event) => setAssignmentForm((prev) => ({ ...prev, lotId: event.target.value }))}
+                        className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                      />
+                    </label>
+                    <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                      Style ref
+                      <input
+                        required
+                        value={assignmentForm.styleRef}
+                        onChange={(event) => setAssignmentForm((prev) => ({ ...prev, styleRef: event.target.value }))}
+                        className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                      />
+                    </label>
+                    <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                      Customer
+                      <input
+                        required
+                        value={assignmentForm.customer}
+                        onChange={(event) => setAssignmentForm((prev) => ({ ...prev, customer: event.target.value }))}
+                        className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                      />
+                    </label>
+                    <div className="md:col-span-3">
+                      <button
+                        type="submit"
+                        disabled={assignMutation.isLoading}
+                        className="mt-2 inline-flex w-full items-center justify-center rounded-full bg-primary-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-primary-700 disabled:opacity-60"
+                      >
+                        {assignMutation.isLoading ? 'Updating…' : 'Assign lot'}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+
+                <div className="rounded-2xl border border-slate-200 bg-white p-4">
+                  <h3 className="text-sm font-semibold text-slate-700">Reprint label</h3>
+                  <form onSubmit={handleReprint} className="mt-4 grid gap-3 md:grid-cols-3">
+                    <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                      Lot ID
+                      <input
+                        required
+                        value={reprintForm.lotId}
+                        onChange={(event) => setReprintForm((prev) => ({ ...prev, lotId: event.target.value }))}
+                        className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                      />
+                    </label>
+                    <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                      Piece #
+                      <input
+                        required
+                        type="number"
+                        min={0}
+                        value={reprintForm.pieceSeq}
+                        onChange={(event) => setReprintForm((prev) => ({ ...prev, pieceSeq: Number(event.target.value) }))}
+                        className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                      />
+                    </label>
+                    <label className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                      Reason
+                      <input
+                        value={reprintForm.reason}
+                        onChange={(event) => setReprintForm((prev) => ({ ...prev, reason: event.target.value }))}
+                        className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                      />
+                    </label>
+                    <div className="md:col-span-3">
+                      <button
+                        type="submit"
+                        disabled={reprintMutation.isLoading}
+                        className="mt-2 inline-flex w-full items-center justify-center rounded-full border border-primary-200 bg-white px-4 py-2 text-sm font-medium text-primary-700 shadow-sm transition hover:border-primary-300 hover:text-primary-900 disabled:opacity-60"
+                      >
+                        {reprintMutation.isLoading ? 'Sending…' : 'Queue reprint command'}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+
+                <EventFeed events={device.recentEvents} />
+              </div>
+
+              <QueueDepthCard data={device.queueDepthHistory} />
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/operator/layout.tsx
+++ b/apps/web/src/app/operator/layout.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { LogOutIcon } from 'lucide-react'
+import { UserRole } from '@qa-dashboard/shared'
+
+import { useAuth } from '@/components/providers/auth-provider'
+import { cn } from '@/lib/utils'
+
+const ALLOWED_ROLES = new Set([UserRole.OPERATOR, UserRole.SUPERVISOR, UserRole.ADMIN])
+
+const NAVIGATION = [
+  { label: 'Devices', href: '/operator' },
+  { label: 'Active lots', href: '/operator/lots' },
+  { label: 'Settings', href: '/operator/settings', roles: [UserRole.SUPERVISOR, UserRole.ADMIN] as UserRole[] },
+]
+
+export default function OperatorLayout({ children }: { children: React.ReactNode }) {
+  const { user, isLoading, logout } = useAuth()
+  const pathname = usePathname()
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-100">
+        <div className="h-10 w-10 animate-spin rounded-full border-2 border-slate-300 border-t-primary-500" />
+      </div>
+    )
+  }
+
+  if (!user) {
+    return null
+  }
+
+  const hasAccess = user.roles?.some((role) => ALLOWED_ROLES.has(role))
+
+  if (!hasAccess) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50">
+        <div className="rounded-2xl border border-slate-200 bg-white p-10 text-center shadow-sm">
+          <h1 className="text-2xl font-semibold text-slate-900">Access restricted</h1>
+          <p className="mt-2 text-sm text-slate-600">
+            The operator workspace is available for operator, supervisor or admin roles only.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-100">
+      <header className="sticky top-0 z-40 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-4">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-500">Cloud operator</p>
+            <h1 className="text-xl font-semibold text-slate-900">QA floor overview</h1>
+          </div>
+          <button
+            onClick={logout}
+            className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:text-slate-900"
+          >
+            <LogOutIcon className="h-4 w-4" aria-hidden />
+            Sign out
+          </button>
+        </div>
+        <div className="border-t border-slate-200">
+          <nav className="mx-auto flex max-w-6xl items-center gap-6 px-4 text-sm font-medium text-slate-600">
+            {NAVIGATION.map((item) => {
+              if (item.roles && !item.roles.some((role) => user.roles?.includes(role))) {
+                return null
+              }
+
+              const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`)
+
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={cn(
+                    'py-3 transition-colors',
+                    isActive ? 'text-primary-600' : 'hover:text-slate-900',
+                  )}
+                >
+                  {item.label}
+                </Link>
+              )
+            })}
+          </nav>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-4 py-8">{children}</main>
+    </div>
+  )
+}

--- a/apps/web/src/app/operator/lot/[id]/page.tsx
+++ b/apps/web/src/app/operator/lot/[id]/page.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import Link from 'next/link'
+import { ArrowLeftIcon, FlagIcon } from 'lucide-react'
+
+import { EventFeed } from '@/components/operator/event-feed'
+import { apiClient } from '@/lib/api'
+import { formatRelativeTime } from '@/lib/utils'
+
+export default function OperatorLotDetailPage() {
+  const params = useParams<{ id: string }>()
+  const lotId = params?.id
+  const queryClient = useQueryClient()
+  const [note, setNote] = useState('')
+  const [selectedEventId, setSelectedEventId] = useState('')
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const { data: lots = [] } = useQuery({
+    queryKey: ['operator', 'lots'],
+    queryFn: () => apiClient.getOperatorActiveLots(),
+  })
+
+  const { data: events = [], isLoading } = useQuery({
+    queryKey: ['operator', 'lot-feed', lotId],
+    queryFn: () => apiClient.getOperatorLotFeed(lotId!),
+    enabled: !!lotId,
+  })
+
+  const summary = useMemo(() => lots.find((item) => item.lotId === lotId), [lots, lotId])
+
+  const mutation = useMutation({
+    mutationFn: (payload: { eventId: string; note: string }) =>
+      apiClient.createOperatorFlag(lotId!, { eventId: payload.eventId, note: payload.note }),
+    onSuccess: (updatedEvent) => {
+      queryClient.setQueryData(['operator', 'lot-feed', lotId], (prev?: typeof events) => {
+        if (!prev) return [updatedEvent]
+        return prev.map((event) => (event.id === updatedEvent.id ? updatedEvent : event))
+      })
+      setFeedback('Flag saved successfully')
+      setError(null)
+      setNote('')
+      setSelectedEventId('')
+    },
+    onError: (err: Error) => {
+      setError(err.message)
+      setFeedback(null)
+    },
+  })
+
+  const photoEvents = events.filter((event) => !!event.thumbnailUrl)
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <Link href="/operator/lots" className="inline-flex items-center gap-1 text-sm text-slate-600 hover:text-slate-900">
+          <ArrowLeftIcon className="h-4 w-4" aria-hidden />
+          Back to lots
+        </Link>
+
+        <div className="mt-4 flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-500">{summary?.styleRef ?? '—'}</p>
+            <h1 className="text-2xl font-semibold text-slate-900">Lot {summary?.lotCode ?? lotId}</h1>
+            <p className="text-sm text-slate-600">{summary?.customer ?? 'Unknown customer'}</p>
+          </div>
+          {summary?.lastEventAt && (
+            <p className="text-xs text-slate-500">Updated {formatRelativeTime(summary.lastEventAt)}</p>
+          )}
+        </div>
+
+        {feedback && (
+          <div className="mt-4 rounded-lg bg-emerald-50 px-4 py-3 text-sm text-emerald-700">{feedback}</div>
+        )}
+        {error && <div className="mt-4 rounded-lg bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>}
+
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (!selectedEventId || !note) {
+              setError('Select an event and provide a note before saving a flag.')
+              setFeedback(null)
+              return
+            }
+            mutation.mutate({ eventId: selectedEventId, note })
+          }}
+          className="mt-6 grid gap-3 md:grid-cols-6"
+        >
+          <label className="md:col-span-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+            Event
+            <select
+              required
+              value={selectedEventId}
+              onChange={(event) => setSelectedEventId(event.target.value)}
+              className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            >
+              <option value="">Select an event</option>
+              {events.map((event) => (
+                <option key={event.id} value={event.id}>
+                  {event.type.toLowerCase()} &middot; {formatRelativeTime(event.timestamp)}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="md:col-span-3 text-xs font-medium uppercase tracking-wide text-slate-500">
+            Note
+            <input
+              required
+              value={note}
+              onChange={(event) => setNote(event.target.value)}
+              placeholder="Describe the observation"
+              className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+            />
+          </label>
+
+          <button
+            type="submit"
+            disabled={mutation.isLoading}
+            className="md:col-span-1 mt-6 inline-flex h-10 items-center justify-center gap-2 rounded-full bg-primary-600 px-4 text-sm font-medium text-white shadow-sm transition hover:bg-primary-700 disabled:opacity-60"
+          >
+            <FlagIcon className="h-4 w-4" aria-hidden />
+            {mutation.isLoading ? 'Saving…' : 'Flag event'}
+          </button>
+        </form>
+      </section>
+
+      {isLoading ? (
+        <div className="flex min-h-[160px] items-center justify-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-2 border-slate-300 border-t-primary-500" />
+        </div>
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-2">
+          <EventFeed events={events} className="h-full" />
+
+          <div className="space-y-4">
+            <div className="rounded-2xl border border-slate-200 bg-white p-4">
+              <h3 className="text-sm font-semibold text-slate-700">Photo stream</h3>
+              {photoEvents.length === 0 ? (
+                <p className="mt-2 text-sm text-slate-500">No photos received for this lot yet.</p>
+              ) : (
+                <div className="mt-3 grid grid-cols-2 gap-3">
+                  {photoEvents.map((event) => (
+                    <figure key={event.id} className="overflow-hidden rounded-xl border border-slate-200">
+                      <img src={event.thumbnailUrl!} alt={event.transcript ?? 'Inspection photo'} className="h-32 w-full object-cover" />
+                      <figcaption className="px-3 py-2 text-xs text-slate-600">
+                        {formatRelativeTime(event.timestamp)}
+                      </figcaption>
+                    </figure>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/operator/lots/page.tsx
+++ b/apps/web/src/app/operator/lots/page.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import Link from 'next/link'
+import { ActivityIcon } from 'lucide-react'
+
+import { apiClient } from '@/lib/api'
+import { formatNumber, formatPercentage } from '@/lib/utils'
+
+export default function OperatorLotsPage() {
+  const { data: lots = [], isLoading } = useQuery({
+    queryKey: ['operator', 'lots'],
+    queryFn: () => apiClient.getOperatorActiveLots(),
+  })
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-xl font-semibold text-slate-900">Active lots</h2>
+        <p className="mt-1 text-sm text-slate-600">
+          Aggregated inspection progress, device coverage and defect rate for lots currently in QA.
+        </p>
+      </section>
+
+      {isLoading ? (
+        <div className="flex min-h-[200px] items-center justify-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-2 border-slate-300 border-t-primary-500" />
+        </div>
+      ) : lots.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-12 text-center text-slate-600">
+          No active lots in progress.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {lots.map((lot) => (
+            <Link
+              key={lot.lotId}
+              href={`/operator/lot/${lot.lotId}`}
+              className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-primary-200 hover:shadow-md"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">{lot.styleRef}</p>
+                  <h3 className="text-lg font-semibold text-slate-900">Lot {lot.lotCode}</h3>
+                  <p className="text-sm text-slate-600">{lot.customer}</p>
+                </div>
+                <span className="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-xs font-medium text-slate-700">
+                  <ActivityIcon className="h-4 w-4" aria-hidden />
+                  {lot.activeDeviceIds.length} device{lot.activeDeviceIds.length === 1 ? '' : 's'}
+                </span>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-3">
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Pieces inspected</p>
+                  <p className="text-xl font-semibold text-slate-900">{formatNumber(lot.piecesInspected)}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Defects found</p>
+                  <p className="text-xl font-semibold text-slate-900">{formatNumber(lot.defectsFound)}</p>
+                </div>
+                <div>
+                  <p className="text-xs uppercase tracking-wide text-slate-500">Defect rate</p>
+                  <p className="text-xl font-semibold text-slate-900">{formatPercentage(lot.defectRate * 100)}</p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/operator/page.tsx
+++ b/apps/web/src/app/operator/page.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { FilterIcon } from 'lucide-react'
+
+import { DeviceCard } from '@/components/operator/device-card'
+import { apiClient } from '@/lib/api'
+
+const ALL_SITES = 'all-sites'
+
+export default function OperatorHomePage() {
+  const [site, setSite] = useState<string>(ALL_SITES)
+
+  const { data: devices = [], isLoading } = useQuery({
+    queryKey: ['operator', 'devices', site],
+    queryFn: () => apiClient.getOperatorDevices(site === ALL_SITES ? undefined : site),
+  })
+
+  const availableSites = useMemo(() => {
+    const unique = new Set<string>()
+    devices.forEach((device) => {
+      if (device.site) {
+        unique.add(device.site)
+      }
+    })
+    return Array.from(unique).sort((a, b) => a.localeCompare(b))
+  }, [devices])
+
+  return (
+    <div className="space-y-6">
+      <section className="flex flex-col justify-between gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm md:flex-row md:items-center">
+        <div>
+          <h2 className="text-xl font-semibold text-slate-900">Devices</h2>
+          <p className="text-sm text-slate-600">
+            Monitor queue depth, live assignments and recent edge events per inspection device.
+          </p>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm text-slate-700">
+          <FilterIcon className="h-4 w-4" aria-hidden />
+          <span className="sr-only">Filter by site</span>
+          <select
+            value={site}
+            onChange={(event) => setSite(event.target.value)}
+            className="rounded-full border border-slate-200 bg-white px-4 py-2 text-sm focus:border-primary-400 focus:outline-none focus:ring-2 focus:ring-primary-200"
+          >
+            <option value={ALL_SITES}>All sites</option>
+            {availableSites.map((entry) => (
+              <option key={entry} value={entry}>
+                {entry}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      {isLoading ? (
+        <div className="flex min-h-[200px] items-center justify-center">
+          <div className="h-10 w-10 animate-spin rounded-full border-2 border-slate-300 border-t-primary-500" />
+        </div>
+      ) : devices.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-12 text-center text-slate-600">
+          No devices registered for this site yet.
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {devices.map((device) => (
+            <DeviceCard key={device.id} device={device} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/operator/settings/page.tsx
+++ b/apps/web/src/app/operator/settings/page.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useAuth } from '@/components/providers/auth-provider'
+import { UserRole } from '@qa-dashboard/shared'
+
+export default function OperatorSettingsPage() {
+  const { user } = useAuth()
+  const canEdit = user?.roles?.some((role) => role === UserRole.SUPERVISOR || role === UserRole.ADMIN)
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-xl font-semibold text-slate-900">Site configuration</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Review offline thresholds, camera firmware versions and label templates for each device. This view
+          summarises the values currently used by the edge API.
+        </p>
+      </section>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="rounded-2xl border border-slate-200 bg-white p-5">
+          <h3 className="text-sm font-semibold text-slate-700">Offline queue thresholds</h3>
+          <p className="mt-2 text-sm text-slate-600">
+            Tablets warn operators when the local queue exceeds <strong>5 items</strong> or the last sync is older than
+            <strong> 10 minutes</strong>. These defaults ensure visibility even when the network is unstable.
+          </p>
+          {!canEdit && (
+            <p className="mt-3 text-xs text-slate-500">
+              Supervisor privileges are required to edit thresholds.
+            </p>
+          )}
+        </div>
+
+        <div className="rounded-2xl border border-slate-200 bg-white p-5">
+          <h3 className="text-sm font-semibold text-slate-700">Firmware cadence</h3>
+          <p className="mt-2 text-sm text-slate-600">
+            Edge devices currently run firmware versions 1.3.9 to 1.4.2. The API exposes upgrade windows every Friday at
+            22:00 local time to avoid disrupting shifts.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/operator/device-card.tsx
+++ b/apps/web/src/components/operator/device-card.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import Link from 'next/link'
+import { ArrowRightIcon, ClockIcon, LayersIcon } from 'lucide-react'
+import {
+  OperatorDevice,
+  OperatorAssignment,
+} from '@qa-dashboard/shared'
+
+import { DeviceStatusPill } from './device-status-pill'
+import { cn, formatRelativeTime } from '@/lib/utils'
+
+interface DeviceCardProps {
+  device: OperatorDevice
+  className?: string
+}
+
+function AssignmentSummary({ assignment }: { assignment: OperatorAssignment }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-sm font-medium text-gray-900">Lot {assignment.lotId}</p>
+      <p className="text-xs text-gray-600">
+        {assignment.styleRef} &middot; {assignment.customer}
+      </p>
+      <p className="flex items-center gap-1 text-xs text-gray-500">
+        <ClockIcon className="h-3.5 w-3.5" aria-hidden />
+        Assigned {formatRelativeTime(assignment.assignedAt)}
+      </p>
+    </div>
+  )
+}
+
+export function DeviceCard({ device, className }: DeviceCardProps) {
+  const assignment = device.currentAssignment
+
+  return (
+    <Link
+      href={`/operator/device/${device.id}`}
+      className={cn(
+        'group flex flex-col rounded-2xl border border-gray-200 bg-white p-5 shadow-sm transition-all hover:border-primary-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
+        className,
+      )}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-wider text-gray-500">{device.site}</p>
+          <h3 className="mt-1 text-lg font-semibold text-gray-900">{device.name}</h3>
+          <p className="mt-1 text-xs text-gray-500">
+            Last seen {device.lastSeenAt ? formatRelativeTime(device.lastSeenAt) : 'never'}
+          </p>
+        </div>
+        <DeviceStatusPill status={device.status} />
+      </div>
+
+      <div className="mt-6 grid grid-cols-2 gap-4 text-sm">
+        <div className="rounded-xl bg-slate-50 p-3">
+          <div className="flex items-center gap-2 text-slate-600">
+            <LayersIcon className="h-4 w-4" aria-hidden />
+            Queue depth
+          </div>
+          <p className="mt-2 text-2xl font-semibold text-slate-900">{device.queueDepth}</p>
+        </div>
+
+        <div className="rounded-xl bg-slate-50 p-3">
+          <div className="flex items-center gap-2 text-slate-600">
+            <ArrowRightIcon className="h-4 w-4" aria-hidden />
+            Assignment
+          </div>
+          {assignment ? (
+            <AssignmentSummary assignment={assignment} />
+          ) : (
+            <p className="mt-2 text-sm text-slate-500">No active lot</p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between text-sm text-primary-600">
+        <span className="flex items-center gap-1">
+          View device
+          <ArrowRightIcon className="h-4 w-4 transition-transform group-hover:translate-x-0.5" />
+        </span>
+      </div>
+    </Link>
+  )
+}

--- a/apps/web/src/components/operator/device-metrics.tsx
+++ b/apps/web/src/components/operator/device-metrics.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { GaugeIcon, MessageSquareIcon, ZapIcon } from 'lucide-react'
+import { OperatorDeviceDetail } from '@qa-dashboard/shared'
+
+import { formatRelativeTime } from '@/lib/utils'
+
+interface DeviceMetricsProps {
+  device: OperatorDeviceDetail
+}
+
+export function DeviceMetrics({ device }: DeviceMetricsProps) {
+  const { metrics } = device
+  const qa = metrics.qaIndicators
+
+  const lastEventAt = device.recentEvents[0]?.timestamp
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+      <div className="rounded-2xl border border-slate-200 bg-white p-4">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+          <ZapIcon className="h-4 w-4" aria-hidden />
+          Current piece
+        </div>
+        <p className="mt-3 text-3xl font-semibold text-slate-900">#{metrics.pieceSequence}</p>
+        <p className="mt-1 text-xs text-slate-500">
+          Updated {lastEventAt ? formatRelativeTime(lastEventAt) : 'recently'}
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-4">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+          <GaugeIcon className="h-4 w-4" aria-hidden />
+          QA metrics
+        </div>
+        <dl className="mt-3 space-y-2 text-sm">
+          <div className="flex items-center justify-between">
+            <dt className="text-slate-500">Px/mm</dt>
+            <dd className="font-medium text-slate-900">
+              {qa.pixelsPerMillimeter ? qa.pixelsPerMillimeter.toFixed(1) : '—'}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between">
+            <dt className="text-slate-500">Sharpness</dt>
+            <dd className="font-medium text-slate-900">
+              {qa.sharpnessScore ? Math.round(qa.sharpnessScore * 100) : '—'}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between">
+            <dt className="text-slate-500">Brightness</dt>
+            <dd className="font-medium text-slate-900">
+              {qa.brightnessScore ? Math.round(qa.brightnessScore * 100) : '—'}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between">
+            <dt className="text-slate-500">Status</dt>
+            <dd
+              className="rounded-full bg-slate-100 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-slate-700"
+            >
+              {qa.status}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-4">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+          <MessageSquareIcon className="h-4 w-4" aria-hidden />
+          Transcript
+        </div>
+        <p className="mt-3 text-sm text-slate-600">
+          {metrics.lastTranscript ?? 'No transcript available'}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/operator/device-status-pill.tsx
+++ b/apps/web/src/components/operator/device-status-pill.tsx
@@ -1,0 +1,38 @@
+import { DeviceStatus } from '@qa-dashboard/shared'
+
+import { cn } from '@/lib/utils'
+
+const STATUS_STYLES: Record<DeviceStatus, { label: string; className: string }> = {
+  [DeviceStatus.ONLINE]: {
+    label: 'Online',
+    className: 'bg-emerald-100 text-emerald-700 border border-emerald-200',
+  },
+  [DeviceStatus.OFFLINE]: {
+    label: 'Offline',
+    className: 'bg-gray-100 text-gray-600 border border-gray-200',
+  },
+  [DeviceStatus.DEGRADED]: {
+    label: 'Degraded',
+    className: 'bg-amber-100 text-amber-700 border border-amber-200',
+  },
+}
+
+interface DeviceStatusPillProps {
+  status: DeviceStatus
+}
+
+export function DeviceStatusPill({ status }: DeviceStatusPillProps) {
+  const { label, className } = STATUS_STYLES[status]
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium tracking-wide uppercase',
+        className,
+      )}
+    >
+      <span className="h-1.5 w-1.5 rounded-full bg-current" aria-hidden />
+      {label}
+    </span>
+  )
+}

--- a/apps/web/src/components/operator/event-feed.tsx
+++ b/apps/web/src/components/operator/event-feed.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { CameraIcon, FlagIcon, PrinterIcon, ShieldCheckIcon } from 'lucide-react'
+import { OperatorLotFeedItem, EdgeEventType } from '@qa-dashboard/shared'
+
+import { cn, formatRelativeTime } from '@/lib/utils'
+
+interface EventFeedProps {
+  events: OperatorLotFeedItem[]
+  className?: string
+}
+
+const ICONS: Record<EdgeEventType, typeof CameraIcon> = {
+  [EdgeEventType.PHOTO]: CameraIcon,
+  [EdgeEventType.DEFECT]: FlagIcon,
+  [EdgeEventType.PIECE_END]: ShieldCheckIcon,
+  [EdgeEventType.PRINT_LABEL]: PrinterIcon,
+  [EdgeEventType.HEARTBEAT]: ShieldCheckIcon,
+  [EdgeEventType.FLAG]: FlagIcon,
+}
+
+export function EventFeed({ events, className }: EventFeedProps) {
+  return (
+    <div
+      className={cn(
+        'space-y-3 overflow-hidden rounded-2xl border border-slate-200 bg-white p-4',
+        className,
+      )}
+    >
+      <h3 className="text-sm font-semibold text-slate-700">Recent activity</h3>
+
+      <ul className="divide-y divide-slate-100">
+        {events.map((event) => {
+          const Icon = ICONS[event.type]
+
+          return (
+            <li key={event.id} className="flex items-start gap-3 py-3">
+              <span className="flex h-10 w-10 items-center justify-center rounded-xl bg-slate-50 text-slate-600">
+                <Icon className="h-5 w-5" aria-hidden />
+              </span>
+              <div className="flex-1 space-y-1">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium text-slate-900 capitalize">{event.type.toLowerCase()}</p>
+                  <span className="text-xs text-slate-500">{formatRelativeTime(event.timestamp)}</span>
+                </div>
+                {event.transcript && <p className="text-sm text-slate-600">{event.transcript}</p>}
+                {event.defectText && (
+                  <p className="text-sm font-medium text-amber-700">{event.defectText}</p>
+                )}
+                {event.flag && (
+                  <p className="rounded-lg bg-amber-50 px-2 py-1 text-xs text-amber-800">
+                    {event.flag.note}
+                  </p>
+                )}
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/apps/web/src/components/operator/queue-depth-card.tsx
+++ b/apps/web/src/components/operator/queue-depth-card.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { LineChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { QueueDepthSample } from '@qa-dashboard/shared'
+
+interface QueueDepthCardProps {
+  data: QueueDepthSample[]
+}
+
+export function QueueDepthCard({ data }: QueueDepthCardProps) {
+  const chartData = data
+    .slice()
+    .reverse()
+    .map((sample) => ({
+      time: new Date(sample.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+      depth: sample.depth,
+    }))
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-4">
+      <h3 className="text-sm font-semibold text-slate-700">Offline queue</h3>
+      <p className="text-xs text-slate-500">Last hour</p>
+      <div className="mt-4 h-40">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={chartData}>
+            <XAxis dataKey="time" tickLine={false} axisLine={false} fontSize={12} />
+            <YAxis allowDecimals={false} tickLine={false} axisLine={false} fontSize={12} width={24} />
+            <Tooltip cursor={{ strokeDasharray: '3 3' }} />
+            <Line type="monotone" dataKey="depth" stroke="#2563eb" strokeWidth={2} dot={false} />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -14,6 +14,14 @@ import {
   LotStatus,
   SupplyChainRole,
   LotSupplierRole,
+  OperatorDevice,
+  OperatorDeviceDetail,
+  OperatorLotSummary,
+  OperatorLotFeedItem,
+  OperatorCommandResult,
+  OperatorAssignLotPayload,
+  OperatorReprintPayload,
+  OperatorFlagPayload,
 } from '@qa-dashboard/shared'
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3001'
@@ -79,6 +87,56 @@ class ApiClient {
 
     Cookies.set('accessToken', response.accessToken, { expires: 1 / 24 })
     return response
+  }
+
+  // Operator endpoints
+  async getOperatorDevices(site?: string): Promise<OperatorDevice[]> {
+    const query = site ? `?site=${encodeURIComponent(site)}` : ''
+    return this.request<OperatorDevice[]>(`/operator/devices${query}`)
+  }
+
+  async getOperatorDevice(deviceId: string): Promise<OperatorDeviceDetail> {
+    return this.request<OperatorDeviceDetail>(`/operator/devices/${deviceId}`)
+  }
+
+  async assignOperatorDevice(
+    deviceId: string,
+    payload: OperatorAssignLotPayload,
+  ): Promise<OperatorDeviceDetail> {
+    return this.request<OperatorDeviceDetail>(`/operator/devices/${deviceId}/assign`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+  }
+
+  async issueReprintCommand(
+    deviceId: string,
+    payload: OperatorReprintPayload,
+  ): Promise<OperatorCommandResult> {
+    return this.request<OperatorCommandResult>(`/operator/devices/${deviceId}/commands/reprint`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+  }
+
+  async getOperatorActiveLots(site?: string): Promise<OperatorLotSummary[]> {
+    const query = site ? `?site=${encodeURIComponent(site)}` : ''
+    return this.request<OperatorLotSummary[]>(`/operator/lots/active${query}`)
+  }
+
+  async getOperatorLotFeed(lotId: string, site?: string): Promise<OperatorLotFeedItem[]> {
+    const query = site ? `?site=${encodeURIComponent(site)}` : ''
+    return this.request<OperatorLotFeedItem[]>(`/operator/lots/${lotId}/feed${query}`)
+  }
+
+  async createOperatorFlag(
+    lotId: string,
+    payload: OperatorFlagPayload,
+  ): Promise<OperatorLotFeedItem> {
+    return this.request<OperatorLotFeedItem>(`/operator/lots/${lotId}/flags`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
   }
 
   // Inspections

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -6,6 +6,8 @@ export enum UserRole {
   INSPECTOR = "INSPECTOR",
   CLIENT_VIEWER = "CLIENT_VIEWER",
   CLEVEL = "CLEVEL",
+  SUPERVISOR = "SUPERVISOR",
+  OPERATOR = "OPERATOR",
 }
 
 export enum FactoryCertificationType {
@@ -196,6 +198,128 @@ export interface SupplyChainRole {
   defaultCo2Kg: number;
   createdAt?: string;
   updatedAt?: string;
+}
+
+export enum DeviceStatus {
+  ONLINE = "ONLINE",
+  OFFLINE = "OFFLINE",
+  DEGRADED = "DEGRADED",
+}
+
+export enum EdgeEventType {
+  DEFECT = "DEFECT",
+  PHOTO = "PHOTO",
+  PIECE_END = "PIECE_END",
+  PRINT_LABEL = "PRINT_LABEL",
+  HEARTBEAT = "HEARTBEAT",
+  FLAG = "FLAG",
+}
+
+export enum DeviceCommandType {
+  REPRINT_LABEL = "REPRINT_LABEL",
+  SWITCH_LOT = "SWITCH_LOT",
+}
+
+export interface OperatorAssignment {
+  lotId: string;
+  styleRef: string;
+  customer: string;
+  assignedAt: string;
+  assignedBy?: string;
+}
+
+export interface QueueDepthSample {
+  timestamp: string;
+  depth: number;
+}
+
+export interface OperatorDevice {
+  id: string;
+  name: string;
+  site: string;
+  status: DeviceStatus;
+  lastSeenAt: string | null;
+  queueDepth: number;
+  firmwareVersion?: string | null;
+  ipAddress?: string | null;
+  currentAssignment?: OperatorAssignment | null;
+}
+
+export interface OperatorDeviceDetail extends OperatorDevice {
+  metrics: {
+    pieceSequence: number;
+    qaIndicators: {
+      pixelsPerMillimeter?: number;
+      sharpnessScore?: number;
+      brightnessScore?: number;
+      status: "ok" | "warning" | "critical";
+    };
+    lastTranscript?: string | null;
+  };
+  recentEvents: OperatorLotFeedItem[];
+  queueDepthHistory: QueueDepthSample[];
+}
+
+export interface OperatorLotSummary {
+  lotId: string;
+  lotCode: string;
+  customer: string;
+  styleRef: string;
+  activeDeviceIds: string[];
+  piecesInspected: number;
+  defectsFound: number;
+  defectRate: number;
+  lastEventAt: string | null;
+}
+
+export interface OperatorLotFeedItem {
+  id: string;
+  lotId: string;
+  deviceId: string;
+  type: EdgeEventType;
+  timestamp: string;
+  pieceSequence?: number;
+  thumbnailUrl?: string;
+  transcript?: string;
+  defectText?: string;
+  qaMetrics?: {
+    pixelsPerMillimeter?: number;
+    sharpnessScore?: number;
+    brightnessScore?: number;
+    status: "ok" | "warning" | "critical";
+  };
+  flag?: {
+    note: string;
+    createdBy: string;
+    createdAt: string;
+    severity?: "info" | "warning" | "critical";
+  };
+}
+
+export interface OperatorCommandResult {
+  commandId: string;
+  deviceId: string;
+  type: DeviceCommandType;
+  status: "QUEUED" | "SENT" | "ACKED";
+  createdAt: string;
+}
+
+export interface OperatorAssignLotPayload {
+  lotId: string;
+  styleRef: string;
+  customer: string;
+}
+
+export interface OperatorReprintPayload {
+  lotId: string;
+  pieceSeq: number;
+  reason?: string;
+}
+
+export interface OperatorFlagPayload {
+  eventId: string;
+  note: string;
+  severity?: "info" | "warning" | "critical";
 }
 
 export interface FactoryCapability {


### PR DESCRIPTION
## Summary
- extend shared contracts with operator-specific roles, device states, and command payloads
- add a NestJS operator module exposing mock devices, lots, commands, and flag APIs backed by in-memory seed data
- scaffold the tablet-friendly operator workspace in Next.js with device dashboards, lot views, realtime summaries, and control forms

## Testing
- npm run build:shared
- npm run build:api

------
https://chatgpt.com/codex/tasks/task_e_68d8657a6864832c96254705a2d3b956