### PR TITLE
Fix lint issues in admin and gallery pages

### DIFF
--- a/apps/web/src/app/admin/devices/page.tsx
+++ b/apps/web/src/app/admin/devices/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { apiClient } from '@/lib/api'
 
 interface Device {
@@ -48,11 +48,7 @@ export default function DevicesPage() {
     workbenchNumber: 1,
   })
 
-  useEffect(() => {
-    loadData()
-  }, [selectedTenantFilter])
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true)
       const [devicesRes, tenantsRes, operatorsRes] = await Promise.all([
@@ -68,7 +64,11 @@ export default function DevicesPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [selectedTenantFilter])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
 
   const handleCreateDevice = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -347,7 +347,7 @@ export default function DevicesPage() {
           <div className="bg-white rounded-lg p-6 max-w-lg w-full">
             <h3 className="text-lg font-semibold mb-4 text-green-600">✓ Device Created Successfully</h3>
             <p className="text-sm text-slate-600 mb-4">
-              Save this device secret securely. You won't be able to see it again!
+              Save this device secret securely. You won’t be able to see it again!
             </p>
             <div className="bg-slate-100 p-4 rounded-lg mb-4">
               <code className="text-sm font-mono break-all">{newDeviceSecret}</code>

--- a/apps/web/src/app/admin/operators/page.tsx
+++ b/apps/web/src/app/admin/operators/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { apiClient } from '@/lib/api'
 
 interface Operator {
@@ -32,11 +32,7 @@ export default function OperatorsPage() {
     password: '',
   })
 
-  useEffect(() => {
-    loadData()
-  }, [selectedTenantFilter])
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true)
       const [operatorsRes, tenantsRes] = await Promise.all([
@@ -50,7 +46,11 @@ export default function OperatorsPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [selectedTenantFilter])
+
+  useEffect(() => {
+    loadData()
+  }, [loadData])
 
   const handleCreateOperator = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/apps/web/src/app/c/[tenantSlug]/lots/[id]/gallery/page.tsx
+++ b/apps/web/src/app/c/[tenantSlug]/lots/[id]/gallery/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { apiClient } from '@/lib/api'
 import Link from 'next/link'
@@ -17,11 +17,7 @@ export default function LotGalleryPage() {
   const [statusFilter, setStatusFilter] = useState('')
   const [selectedPhoto, setSelectedPhoto] = useState<any>(null)
 
-  useEffect(() => {
-    loadGallery()
-  }, [lotId, statusFilter])
-
-  const loadGallery = async () => {
+  const loadGallery = useCallback(async () => {
     if (!lotId) return
 
     try {
@@ -33,7 +29,11 @@ export default function LotGalleryPage() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [lotId, statusFilter])
+
+  useEffect(() => {
+    loadGallery()
+  }, [loadGallery])
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- wrap data-loading helpers in useCallback so they can be safely used in useEffect dependencies
- update the device secret modal copy to avoid the react/no-unescaped-entities lint violation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db953591e8832c87b7add01324af99