### PR TITLE
Use Next Image for photo displays and align report modal props

### DIFF
--- a/apps/web/src/app/admin/tenants/page.tsx
+++ b/apps/web/src/app/admin/tenants/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import Image from 'next/image'
 import { apiClient } from '@/lib/api'
 
 interface Tenant {
@@ -87,7 +88,13 @@ export default function TenantsPage() {
                     <div className="flex items-center">
                       <div className="flex-shrink-0 h-10 w-10">
                         {tenant.logoUrl ? (
-                          <img className="h-10 w-10 rounded-full" src={tenant.logoUrl} alt="" />
+                          <Image
+                            className="h-10 w-10 rounded-full object-cover"
+                            src={tenant.logoUrl}
+                            alt={`${tenant.name} logo`}
+                            width={40}
+                            height={40}
+                          />
                         ) : (
                           <div className="h-10 w-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-semibold">
                             {tenant.name.charAt(0)}

--- a/apps/web/src/app/c/[tenantSlug]/feed/page.tsx
+++ b/apps/web/src/app/c/[tenantSlug]/feed/page.tsx
@@ -15,6 +15,7 @@ import { useToast } from '@/components/ui/toast'
 import { PageHeader } from '@/components/ui/page-header'
 import { TextArea } from '@/components/ui/input'
 import { useParams, useRouter } from 'next/navigation'
+import Image from 'next/image'
 import { ActivityIcon, AlertTriangleIcon } from 'lucide-react'
 
 export default function LiveFeedPage() {
@@ -420,10 +421,13 @@ function DefectReviewModal({
                   key={photo.id}
                   className="overflow-hidden rounded-lg border border-neutral-200 bg-neutral-100 dark:border-neutral-700 dark:bg-neutral-800"
                 >
-                  <img
+                  <Image
                     src={`/api/photos/${photo.filePath}`}
-                    alt="Defect"
+                    alt="Defect photo"
                     className="h-40 w-full object-cover"
+                    width={400}
+                    height={160}
+                    sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
                     onError={(e) => {
                       e.currentTarget.src =
                         'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="200" height="200"%3E%3Crect fill="%23e2e8f0" width="200" height="200"/%3E%3Ctext x="50%25" y="50%25" dominant-baseline="middle" text-anchor="middle" fill="%2394a3b8" font-size="48"%3E📷%3C/text%3E%3C/svg%3E'

--- a/apps/web/src/app/c/[tenantSlug]/lots/[id]/gallery/page.tsx
+++ b/apps/web/src/app/c/[tenantSlug]/lots/[id]/gallery/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { apiClient } from '@/lib/api'
 import Link from 'next/link'
+import Image from 'next/image'
 
 export default function LotGalleryPage() {
   const params = useParams()
@@ -123,10 +124,13 @@ export default function LotGalleryPage() {
               onClick={() => setSelectedPhoto(photo)}
               className="group relative aspect-square bg-slate-100 rounded-xl overflow-hidden shadow-md hover:shadow-xl transition"
             >
-              <img
+              <Image
                 src={`/api/photos/${photo.filePath}`}
                 alt={`Piece #${photo.pieceNumber}`}
                 className="w-full h-full object-cover"
+                width={400}
+                height={400}
+                sizes="(min-width: 1536px) 15vw, (min-width: 1280px) 20vw, (min-width: 1024px) 25vw, (min-width: 768px) 33vw, 50vw"
                 onError={(e) => {
                   e.currentTarget.src =
                     'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="200" height="200"%3E%3Crect fill="%23e2e8f0" width="200" height="200"/%3E%3Ctext x="50%25" y="50%25" dominant-baseline="middle" text-anchor="middle" fill="%2394a3b8" font-size="48"%3E📷%3C/text%3E%3C/svg%3E'
@@ -180,10 +184,13 @@ export default function LotGalleryPage() {
             </div>
 
             <div className="bg-white rounded-xl overflow-hidden">
-              <img
+              <Image
                 src={`/api/photos/${selectedPhoto.filePath}`}
                 alt={`Piece #${selectedPhoto.pieceNumber}`}
                 className="w-full h-auto max-h-[70vh] object-contain"
+                width={1200}
+                height={900}
+                sizes="90vw"
                 onError={(e) => {
                   e.currentTarget.src =
                     'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="800" height="600"%3E%3Crect fill="%23e2e8f0" width="800" height="600"/%3E%3Ctext x="50%25" y="50%25" dominant-baseline="middle" text-anchor="middle" fill="%2394a3b8" font-size="64"%3E📷%3C/text%3E%3C/svg%3E'

--- a/apps/web/src/app/c/[tenantSlug]/lots/[id]/page.tsx
+++ b/apps/web/src/app/c/[tenantSlug]/lots/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import Image from 'next/image'
 import { apiClient } from '@/lib/api'
 import { useAuth } from '@/components/providers/auth-provider'
 import { LotHeader } from '@/components/lots/lot-header'
@@ -327,7 +328,14 @@ export default function LotDetailPage() {
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                       {(defect.photos || []).map((photo) => (
                         <figure key={photo.id} className="bg-white rounded border border-gray-200 overflow-hidden">
-                          <img src={photo.url} alt="Inspection evidence" className="w-full h-40 object-cover" />
+                          <Image
+                            src={photo.url}
+                            alt="Inspection evidence"
+                            className="w-full h-40 object-cover"
+                            width={400}
+                            height={160}
+                            sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
+                          />
                           {photo.annotation && (
                             <figcaption className="px-3 py-2 text-xs text-gray-600">
                               {photo.annotation.comment}
@@ -576,7 +584,7 @@ export default function LotDetailPage() {
       <ReportGenerationModal
         isOpen={showReportModal}
         onClose={() => setShowReportModal(false)}
-        onComplete={handleReportGenerated}
+        onSuccess={handleReportGenerated}
         initialType={ReportType.LOT_INSPECTION_REPORT}
         initialLotId={lotId}
       />

--- a/apps/web/src/app/operator/inspection/[sessionId]/page.tsx
+++ b/apps/web/src/app/operator/inspection/[sessionId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react'
 import { useRouter, useParams } from 'next/navigation'
+import Image from 'next/image'
 import { apiClient } from '@/lib/api'
 
 interface SessionData {
@@ -229,10 +230,13 @@ export default function LiveInspectionPage() {
                   key={photo.id}
                   className="relative aspect-square bg-slate-100 rounded-xl overflow-hidden shadow-md hover:shadow-xl transition group"
                 >
-                  <img
+                  <Image
                     src={`/api/photos/${photo.filePath}`}
                     alt="Inspection photo"
                     className="w-full h-full object-cover"
+                    width={400}
+                    height={400}
+                    sizes="(min-width: 1024px) 20vw, (min-width: 768px) 25vw, 45vw"
                     onError={(e) => {
                       e.currentTarget.src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="200" height="200"%3E%3Crect fill="%23e2e8f0" width="200" height="200"/%3E%3Ctext x="50%25" y="50%25" dominant-baseline="middle" text-anchor="middle" fill="%2394a3b8" font-size="48"%3E📷%3C/text%3E%3C/svg%3E'
                     }}

--- a/apps/web/src/app/operator/lot/[id]/page.tsx
+++ b/apps/web/src/app/operator/lot/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import Link from 'next/link'
+import Image from 'next/image'
 import { ArrowLeftIcon, FlagIcon } from 'lucide-react'
 
 import { EventFeed } from '@/components/operator/event-feed'
@@ -145,7 +146,14 @@ export default function OperatorLotDetailPage() {
                 <div className="mt-3 grid grid-cols-2 gap-3">
                   {photoEvents.map((event) => (
                     <figure key={event.id} className="overflow-hidden rounded-xl border border-slate-200">
-                      <img src={event.thumbnailUrl!} alt={event.transcript ?? 'Inspection photo'} className="h-32 w-full object-cover" />
+                      <Image
+                        src={event.thumbnailUrl!}
+                        alt={event.transcript ?? 'Inspection photo'}
+                        className="h-32 w-full object-cover"
+                        width={320}
+                        height={128}
+                        sizes="(min-width: 1024px) 25vw, (min-width: 640px) 33vw, 50vw"
+                      />
                       <figcaption className="px-3 py-2 text-xs text-slate-600">
                         {formatRelativeTime(event.timestamp)}
                       </figcaption>

--- a/apps/web/src/components/inspections/enhanced-inspection-card.tsx
+++ b/apps/web/src/components/inspections/enhanced-inspection-card.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Inspection } from '@qa-dashboard/shared'
+import Image from 'next/image'
 import { formatRelativeTime, cn } from '@/lib/utils'
 import { CameraIcon, ChevronDownIcon, ChevronUpIcon, Factory as FactoryIcon, CheckCircle, XCircle } from 'lucide-react'
 import { apiClient } from '@/lib/api'
@@ -138,10 +139,13 @@ export function EnhancedInspectionCard({ inspection }: EnhancedInspectionCardPro
                 <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-3">
                   {defect.photos?.map((photo) => (
                     <figure key={photo.id} className="border border-gray-200 rounded-md overflow-hidden bg-gray-100">
-                      <img
+                      <Image
                         src={photo.url}
                         alt="Inspection evidence"
                         className="w-full h-40 object-cover"
+                        width={400}
+                        height={160}
+                        sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
                       />
                       {photo.annotation?.comment && (
                         <figcaption className="px-3 py-2 text-xs text-gray-600 flex items-center">

--- a/apps/web/src/components/reports/report-generation-modal.tsx
+++ b/apps/web/src/components/reports/report-generation-modal.tsx
@@ -11,7 +11,7 @@ import { ReportType, ReportLanguage } from '@qa-dashboard/shared'
 interface ReportGenerationModalProps {
   isOpen: boolean
   onClose: () => void
-  onComplete: () => void
+  onSuccess: () => void
   initialType?: ReportType
   initialLotId?: string
 }
@@ -71,7 +71,7 @@ const REPORT_TYPES = [
 export function ReportGenerationModal({
   isOpen,
   onClose,
-  onComplete,
+  onSuccess: onSuccessCallback,
   initialType,
   initialLotId
 }: ReportGenerationModalProps) {
@@ -107,7 +107,7 @@ export function ReportGenerationModal({
       }
     },
     onSuccess: () => {
-      onComplete()
+      onSuccessCallback()
     },
   })
 


### PR DESCRIPTION
## Summary
- replace plain img tags in tenant and photo gallery views with next/image for better optimization and lint compliance
- update the report generation modal to expose an `onSuccess` callback and adjust its callers to resolve build-time type errors

## Testing
- pnpm --filter @qa-dashboard/web lint

------
https://chatgpt.com/codex/tasks/task_e_68dbe2155b3c832cb0ecb1cb69d51bea