### PR TITLE
Fix IconButton aria-label prop handling

### DIFF
--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -93,17 +93,17 @@ export interface IconButtonProps
 }
 
 export const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
-  ({ icon, size = 'sm', ...props }, ref) => (
+  ({ icon, size = 'sm', 'aria-label': ariaLabel, ...props }, ref) => (
     <Button
       ref={ref}
       variant="subtle"
       size={size}
       className={cn('aspect-square p-0')}
       icon={icon}
-      aria-label={props['aria-label']}
+      aria-label={ariaLabel}
       {...props}
     >
-      <span className="sr-only">{props['aria-label']}</span>
+      <span className="sr-only">{ariaLabel}</span>
     </Button>
   ),
 )


### PR DESCRIPTION
## Summary
- prevent IconButton from passing duplicate aria-label props when spreading remaining props
- retain screen reader label by storing the aria-label value locally before spreading

## Testing
- CI=1 pnpm --filter @qa-dashboard/web build *(fails: missing @qa-dashboard/shared module)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe59cafc0832cae503d106336b16e